### PR TITLE
Fix --target js output failing to initialize outside a browser (Cloudflare Workers)

### DIFF
--- a/src/browser/bootstrap.rs
+++ b/src/browser/bootstrap.rs
@@ -339,7 +339,15 @@ pub fn render_fusion_js_bootstrap(functions: &[String], module_name: &str) -> St
     bootstrap.push_str("async function ensureInit() {\n");
     bootstrap.push_str("    if (!__matchboxReady) {\n");
     bootstrap.push_str("        __matchboxReady = (async () => {\n");
-    bootstrap.push_str("            await __wbg_init();\n");
+    // Non-browser hosts (Cloudflare Workers, other WASM-module-import edge
+    // runtimes) have no relative-URL-fetchable `import.meta.url` for the
+    // default `__wbg_init()` fallback to resolve - they get the compiled
+    // WebAssembly.Module directly via their own `.wasm` ES module import
+    // instead. Checking a `globalThis` override here lets that host hand it
+    // in (`globalThis.__matchboxWasmModule = wasmModule` before the first
+    // exported call) without touching browser behavior at all: when the
+    // override isn't set, this is exactly the old zero-arg call.
+    bootstrap.push_str("            await __wbg_init(typeof globalThis !== \"undefined\" && globalThis.__matchboxWasmModule !== undefined ? { module_or_path: globalThis.__matchboxWasmModule } : undefined);\n");
     bootstrap.push_str("            if (!vm) {\n");
     bootstrap.push_str("                vm = new BoxLangVM();\n");
     bootstrap.push_str("                if (typeof window !== \"undefined\" && window.MatchBox && window.MatchBox.registerCallbackBridge) {\n");
@@ -737,7 +745,9 @@ pub fn render_stub_js_bootstrap(
     bootstrap.push_str("async function ensureInit() {\n");
     bootstrap.push_str("    if (!__matchboxReady) {\n");
     bootstrap.push_str("        __matchboxReady = (async () => {\n");
-    bootstrap.push_str("            await __wbg_init();\n");
+    // See the sibling ensureInit() above for why this checks a globalThis
+    // override before falling back to the zero-arg browser-fetch path.
+    bootstrap.push_str("            await __wbg_init(typeof globalThis !== \"undefined\" && globalThis.__matchboxWasmModule !== undefined ? { module_or_path: globalThis.__matchboxWasmModule } : undefined);\n");
     bootstrap.push_str("            if (!vm) {\n");
     bootstrap.push_str("                vm = new BoxLangVM();\n");
     bootstrap.push_str("                if (typeof window !== \"undefined\" && window.MatchBox && window.MatchBox.registerCallbackBridge) {\n");
@@ -871,7 +881,9 @@ mod tests {
         assert!(bootstrap.contains("registerCallbackBridge"));
         assert!(bootstrap.contains("invokeCallback"));
         assert!(bootstrap.contains("BoxLangVM.prototype.free"));
-        assert!(bootstrap.contains("await __wbg_init();"));
+        assert!(bootstrap.contains(
+            "await __wbg_init(typeof globalThis !== \"undefined\" && globalThis.__matchboxWasmModule !== undefined ? { module_or_path: globalThis.__matchboxWasmModule } : undefined);"
+        ));
         assert!(bootstrap.contains("vm = new BoxLangVM();"));
         assert!(bootstrap.contains("vm.init();"));
         assert!(bootstrap.contains("return await vm.call(\"hello\", args);"));
@@ -895,6 +907,7 @@ mod tests {
         assert!(bootstrap.contains("getInstanceKeys"));
         assert!(bootstrap.contains("setInstanceProperty"));
         assert!(bootstrap.contains("wrapInstancePropertyValue"));
+        assert!(bootstrap.contains("globalThis.__matchboxWasmModule"));
         assert!(bootstrap.contains("vm = new BoxLangVM();"));
         assert!(bootstrap.contains("vm.load_bytecode(bytecodeBytes);"));
         assert!(bootstrap.contains("return await vm.call(\"hello\", args);"));


### PR DESCRIPTION
## Summary

- `docs/building-and-deploying/wasm-container.md` documents Cloudflare Workers (via Wrangler) as a supported `--target js` deployment target, but the generated bundle's self-initialization currently throws in any non-browser host.
- The generated bundle's `ensureInit()` runs automatically at module-import time (`export const ready = ensureInit();`) and always calls `__wbg_init()` with **no arguments**. The zero-arg path falls back to `new URL('route.wasm', import.meta.url)` + `fetch()` — a browser-only mechanism that throws `TypeError: Invalid URL string` under Cloudflare Workers (workerd has no relative-URL-fetchable `import.meta.url` for this).
- A Workers host already gets the compiled `WebAssembly.Module` directly via its own native `.wasm` ES module import — there was just no way to hand that module in instead of letting `ensureInit()` hit the browser fetch path.
- Fix: both `ensureInit()` bootstrap variants (Native Fusion and `load_bytecode`) now check `globalThis.__matchboxWasmModule` before falling back to the original zero-arg call. A host sets that global from a small shim module imported *before* the MatchBox output (ES modules evaluate imports depth-first in declaration order, so the shim's assignment lands before `ensureInit()` reads it) and gets a working module — existing browser behavior is completely unchanged when the override isn't set.

## Verification

Compiled a small `.bxs` script with the patched CLI (`matchbox --target js`), wired it into a real Cloudflare Worker project, and ran it under `wrangler dev` (the actual `workerd` runtime, not a mock):

- **Before the fix**: every request threw `TypeError: Invalid URL string` inside `__wbg_init`.
- **After the fix**: real BoxLang execution confirmed via a computed value (not a stub return) and correct control flow across multiple exported functions called through a live HTTP request.

```json
// GET /__health
{
  "engine": "MatchBox",
  "language": "BoxLang",
  "status": "alive",
  "computed": 42,
  "timestamp": "2026-08-26T17:10:31.081Z"
}
```

Shim pattern a Worker needs (happy to add this as a documented example if useful — didn't want to scope-creep this PR):

```js
// init-shim.js — imported before the MatchBox-generated module
import wasmModule from "./route.wasm";
globalThis.__matchboxWasmModule = wasmModule;
```

```js
// index.js
import "./init-shim.js";
import { route } from "./route.js";

export default {
  async fetch(request) {
    return new Response(JSON.stringify(await route(...)));
  }
};
```

## Test plan

- [x] `cargo test --release browser::bootstrap` — 4/4 passing, including the updated assertion for the new call signature and a new assertion confirming the `globalThis` override is present in generated output
- [x] `cargo check --release` — clean (one pre-existing, unrelated `unreachable_patterns` warning in `src/lib.rs`, not touched by this change)
- [x] Manual end-to-end verification against a real Cloudflare Worker running under `wrangler dev` (see above)
- [ ] Not yet verified against a live Cloudflare deployment (only local `wrangler dev`, which runs the real `workerd` engine) — flagging in case a maintainer wants to confirm on a real edge deployment before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01X82VHVGUCDRiQSE9FMvWkD)_