### PR TITLE
Add native HTTP request controls

### DIFF
--- a/crates/matchbox-vm/src/bifs/http.rs
+++ b/crates/matchbox-vm/src/bifs/http.rs
@@ -3,11 +3,67 @@ use crate::types::{BxVM, BxValue, NativeFutureValue};
 
 #[cfg(all(feature = "bif-http", not(target_arch = "wasm32")))]
 use std::fs::File;
-#[cfg(all(feature = "bif-http", not(target_arch = "wasm32")))]
-use std::io::copy;
+#[cfg(feature = "bif-http")]
+use std::time::Duration;
 
 #[cfg(all(feature = "bif-http", target_arch = "wasm32", feature = "js"))]
 use web_sys::{Request, RequestInit, RequestMode};
+
+#[cfg(feature = "bif-http")]
+struct RequestOptions {
+    timeout: Option<Duration>,
+    connection_timeout: Option<Duration>,
+    redirect: bool,
+    no_proxy: bool,
+    ipv4_only: bool,
+}
+
+#[cfg(feature = "bif-http")]
+impl Default for RequestOptions {
+    fn default() -> Self {
+        Self {
+            timeout: Some(Duration::from_secs(30)),
+            connection_timeout: None,
+            redirect: true,
+            no_proxy: false,
+            ipv4_only: false,
+        }
+    }
+}
+
+#[cfg(feature = "bif-http")]
+fn request_bool(vm: &dyn BxVM, spec: usize, key: &str, default: bool) -> Result<bool, String> {
+    if !vm.struct_key_exists(spec, key) {
+        return Ok(default);
+    }
+    let value = vm.struct_get(spec, key);
+    if !value.is_bool() {
+        return Err(format!("http() option '{key}' must be a boolean"));
+    }
+    Ok(value.as_bool())
+}
+
+#[cfg(feature = "bif-http")]
+fn request_timeout(
+    vm: &dyn BxVM,
+    spec: usize,
+    key: &str,
+    default: Option<Duration>,
+) -> Result<Option<Duration>, String> {
+    if !vm.struct_key_exists(spec, key) {
+        return Ok(default);
+    }
+    let seconds = vm.struct_get(spec, key).as_number();
+    let invalid = || {
+        format!("http() option '{key}' must be a non-negative finite number of seconds within the supported clock range")
+    };
+    let duration = Duration::try_from_secs_f64(seconds).map_err(|_| invalid())?;
+    #[cfg(not(target_arch = "wasm32"))]
+    if std::time::Instant::now().checked_add(duration).is_none() {
+        return Err(invalid());
+    }
+    Ok((seconds != 0.0).then_some(duration))
+}
 
 #[cfg(feature = "bif-http")]
 fn request_headers(vm: &mut dyn BxVM, spec: usize) -> Vec<(String, String)> {
@@ -40,13 +96,39 @@ fn request_body(vm: &mut dyn BxVM, spec: usize) -> Option<String> {
 }
 
 #[cfg(all(feature = "bif-http", not(target_arch = "wasm32")))]
+fn request_error(error: reqwest::Error) -> String {
+    if error.is_timeout() {
+        "HTTP request timed out".to_string()
+    } else {
+        format!("HTTP request failed: {}", error.without_url())
+    }
+}
+
+#[cfg(all(feature = "bif-http", not(target_arch = "wasm32")))]
 fn send_http(
     url: &str,
     method: &str,
     headers: &[(String, String)],
     body: Option<String>,
+    options: &RequestOptions,
 ) -> Result<reqwest::blocking::Response, String> {
-    let client = reqwest::blocking::Client::new();
+    let mut builder = reqwest::blocking::Client::builder()
+        .timeout(options.timeout)
+        .connect_timeout(options.connection_timeout)
+        .redirect(if options.redirect {
+            reqwest::redirect::Policy::limited(10)
+        } else {
+            reqwest::redirect::Policy::none()
+        });
+    if options.no_proxy {
+        builder = builder.no_proxy();
+    }
+    if options.ipv4_only {
+        builder = builder.local_address(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+    }
+    let client = builder
+        .build()
+        .map_err(|e| format!("HTTP client configuration failed: {}", e.without_url()))?;
     let mut request = match method {
         "GET" => client.get(url),
         "POST" => client.post(url),
@@ -60,9 +142,11 @@ fn send_http(
     if let Some(body) = body {
         request = request.body(body);
     }
-    request
-        .send()
-        .map_err(|e| format!("HTTP request failed: {e}"))
+    if let Some(timeout) = options.timeout {
+        // The per-request deadline also bounds streamed bodies, not just each blocking read.
+        request = request.timeout(timeout);
+    }
+    request.send().map_err(request_error)
 }
 
 #[cfg(feature = "bif-http")]
@@ -73,6 +157,7 @@ pub fn http_bif(vm: &mut dyn BxVM, args: &[BxValue]) -> Result<BxValue, String> 
     let mut path = None;
     let mut headers = Vec::new();
     let mut body = None;
+    let mut options = RequestOptions::default();
 
     if args.len() == 1 && args[0].as_gc_id().is_some() {
         let id = args[0].as_gc_id().unwrap();
@@ -89,6 +174,12 @@ pub fn http_bif(vm: &mut dyn BxVM, args: &[BxValue]) -> Result<BxValue, String> 
                     path = Some(p);
                 }
             }
+            options.timeout = request_timeout(vm, id, "timeout", options.timeout)?;
+            options.connection_timeout =
+                request_timeout(vm, id, "connectionTimeout", options.connection_timeout)?;
+            options.redirect = request_bool(vm, id, "redirect", options.redirect)?;
+            options.no_proxy = request_bool(vm, id, "noProxy", options.no_proxy)?;
+            options.ipv4_only = request_bool(vm, id, "ipv4Only", options.ipv4_only)?;
             headers = request_headers(vm, id);
             body = request_body(vm, id);
         } else {
@@ -117,18 +208,15 @@ pub fn http_bif(vm: &mut dyn BxVM, args: &[BxValue]) -> Result<BxValue, String> 
         let future = handle.future();
         std::thread::spawn(move || {
             let result = (|| {
-                let mut response = send_http(&url, &method, &headers, body)?;
+                let mut response = send_http(&url, &method, &headers, body, &options)?;
                 let status = response.status().as_u16();
                 if let Some(p) = path {
-                    let mut file = File::create(&p)
-                        .map_err(|e| format!("Failed to create file: {e}"))?;
-                    copy(&mut response, &mut file)
-                        .map_err(|e| format!("Failed to download file: {e}"))?;
+                    let mut file =
+                        File::create(&p).map_err(|e| format!("Failed to create file: {e}"))?;
+                    response.copy_to(&mut file).map_err(request_error)?;
                     Ok(serde_json::json!({ "status": status, "file_path": p }))
                 } else {
-                    let text = response
-                        .text()
-                        .map_err(|e| format!("Failed to read response body: {e}"))?;
+                    let text = response.text().map_err(request_error)?;
                     Ok(serde_json::json!({
                         "status": status,
                         "file_content": text,
@@ -150,7 +238,7 @@ pub fn http_bif(vm: &mut dyn BxVM, args: &[BxValue]) -> Result<BxValue, String> 
 
     #[cfg(all(target_arch = "wasm32", feature = "js"))]
     {
-        let _ = (headers, body);
+        let _ = (headers, body, options);
         let opts = RequestInit::new();
         opts.set_method(&method);
         opts.set_mode(RequestMode::Cors);
@@ -166,49 +254,7 @@ pub fn http_bif(vm: &mut dyn BxVM, args: &[BxValue]) -> Result<BxValue, String> 
 
     #[cfg(all(target_arch = "wasm32", not(feature = "js")))]
     {
-        let _ = (method, headers, body);
+        let _ = (method, headers, body, options);
         Err("http() on wasm requires the `js` feature for browser fetch support.".to_string())
-    }
-}
-
-#[cfg(all(test, feature = "bif-http", not(target_arch = "wasm32")))]
-mod tests {
-    use super::send_http;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
-    use std::thread;
-
-    #[test]
-    fn posts_headers_and_body() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let server = thread::spawn(move || {
-            let (mut sock, _) = listener.accept().unwrap();
-            let mut buf = vec![0_u8; 8192];
-            let n = sock.read(&mut buf).unwrap();
-            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
-            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
-                .unwrap();
-            req
-        });
-
-        let response = send_http(
-            &format!("http://{addr}/v1/chat/completions"),
-            "POST",
-            &[
-                ("Authorization".into(), "Bearer testdev".into()),
-                ("Content-Type".into(), "application/json".into()),
-            ],
-            Some(r#"{"model":"x"}"#.into()),
-        )
-        .unwrap();
-        assert_eq!(response.status().as_u16(), 200);
-        assert_eq!(response.text().unwrap(), "ok");
-
-        let req = server.join().unwrap();
-        let lower = req.to_ascii_lowercase();
-        assert!(lower.contains("authorization: bearer testdev"), "{req}");
-        assert!(lower.contains("content-type: application/json"), "{req}");
-        assert!(req.contains(r#"{"model":"x"}"#), "{req}");
     }
 }

--- a/docs/differences-from-boxlang.md
+++ b/docs/differences-from-boxlang.md
@@ -51,6 +51,7 @@ The JVM BoxLang runtime ships with a very large standard library of BIFs coverin
 | `arrayToList()` | ✅ | ✅ |
 | `abs()`, `min()`, `max()` | ✅ | ✅ |
 | `runAsync()`, `sleep()` | ✅ | ✅ |
+| `http()` | ✅ Native; different API | ✅ |
 | Date / time functions | ❌ | ✅ |
 | JSON encode / decode | ❌ | ✅ |
 | File I/O BIFs | ❌ | ✅ |
@@ -59,6 +60,12 @@ The JVM BoxLang runtime ships with a very large standard library of BIFs coverin
 | `createObject()` (Java) | ❌ | ✅ |
 
 > **Workaround:** Missing BIFs can often be implemented in pure BoxLang and placed in the `prelude.bxs` or a shared include file, or implemented as [Native Fusion](building-and-deploying/native-builds.md#native-fusion-rust-interop) Rust BIFs.
+
+---
+
+## HTTP Client API
+
+Native MatchBox uses `http(requestStruct).get()` and returns JSON text containing the HTTP status and response body or download path. This is not JVM BoxLang's fluent HTTP client API. Request deadlines use seconds; `noProxy` and `ipv4Only` are native MatchBox extensions. WASM HTTP future completion is not implemented. See [HTTP Requests](http.md) for supported options, defaults, and examples.
 
 ---
 
@@ -83,7 +90,7 @@ These BoxLang language features exist in the JVM runtime but are not yet availab
 | :--- | :--- | :--- |
 | `include` / `import` multi-file | ⚠️ Partial | `import` works for classes; `include` not fully supported |
 | Switch / match statements | ❌ | Use `if/else if` chains |
-| `cfhttp` / HTTP requests | ❌ | Use Native Fusion + a Rust HTTP crate |
+| `cfhttp` / HTTP component syntax | ❌ | Use the native [`http()` BIF](http.md) instead |
 | Template / tag syntax | ❌ | Script syntax only |
 | Query of Queries | ❌ | No database layer |
 | Component (`cfc`) files | ❌ | Use `.bxs` class files |

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,95 @@
+# HTTP Requests
+
+Native MatchBox includes `http()` when built with the `bif-http` feature (enabled by default). Requests run in-process; no curl executable or shell is needed. This also works in [standalone native binaries](building-and-deploying/native-builds.md).
+
+## Make a Request
+
+`http()` returns a future. Call `.get()` to wait for completion, then deserialize its JSON result:
+
+```boxlang
+response = jsonDeserialize(http({
+    url: "https://example.com/",
+    timeout: 10
+}).get());
+println(response.status);
+println(response.body);
+```
+
+The response contains:
+
+| Field | Meaning |
+| :--- | :--- |
+| `status` | Numeric HTTP status, such as `200` or `404`. |
+| `body` | Response text, when not downloading to a file. |
+| `file_content` | The same response text as `body`. |
+| `file_path` | Destination path, when downloading to a file instead of returning text. |
+
+For a JSON API, deserialize `response.body` separately to obtain the API's data. HTTP 4xx/5xx statuses are returned normally; check `status` before using the body or downloaded file.
+
+## Request Options
+
+Pass a struct with these case-insensitive keys:
+
+| Option | Default | Behavior |
+| :--- | :--- | :--- |
+| `url` | Required | HTTP or HTTPS URL. |
+| `method` | `"GET"` | `GET`, `POST`, `PUT`, or `DELETE`; case-insensitive. |
+| `headers` | None | Struct of header names and values. |
+| `body` | None | Request body as text. Serialize JSON explicitly when needed. |
+| `path` | None | Write the response body to this file instead of returning text. |
+| `timeout` | `30` | Total network request deadline in **seconds**, including connection, redirects, and response-body reads/downloads. `0` disables this deadline. |
+| `connectionTimeout` | `0` | Connection deadline in **seconds**, including DNS, TCP, and TLS setup. `0` means no separate connection deadline; `timeout` still applies. |
+| `redirect` | `true` | Follow at most 10 redirects. `false` returns the original 3xx response without requesting its target. |
+| `noProxy` | `false` | `true` bypasses system/environment proxies for this request only. Otherwise normal proxy settings apply. |
+| `ipv4Only` | `false` | `true` restricts outgoing connections to IPv4, including connections made after redirects. Otherwise normal IPv4/IPv6 selection applies. |
+
+Both deadlines accept non-negative finite numbers, including fractional seconds. Negative, non-numeric, infinite, NaN, or out-of-range durations are rejected. The three boolean controls require actual `true`/`false` values, not strings or numbers. Explicit `null` is invalid for these five controls; omit a key to use its default.
+
+The total deadline is **not** an inactivity timeout: receiving another chunk does not restart it. If both deadlines are enabled, whichever expires first ends the request.
+
+`ipv4Only` controls this machine's connections. When using a proxy, the proxy chooses its own upstream route. Combine `ipv4Only: true` with `noProxy: true` when you need a direct IPv4 connection.
+
+## Probe a Private Service
+
+With `apiKey` loaded from your application's configuration:
+
+```boxlang
+try {
+    response = jsonDeserialize(http({
+        url: "http://private-agent:8642/api/sessions?limit=1",
+        headers: { Authorization: "Bearer " & apiKey },
+        timeout: 5,
+        connectionTimeout: 2,
+        redirect: false,
+        noProxy: true,
+        ipv4Only: true
+    }).get());
+    println("HTTP status: " & response.status);
+} catch (any error) {
+    println("Probe failed: " & error.message);
+}
+```
+
+Headers stay in-process rather than being passed to a child command's arguments. Avoid logging request structs, credentials, or sensitive response bodies. HTTPS certificate verification remains enabled; these options do not disable TLS checks.
+
+## Downloads and Failures
+
+```boxlang
+response = jsonDeserialize(http({
+    url: "https://example.com/archive.zip",
+    path: "archive.zip.tmp",
+    timeout: 60
+}).get());
+```
+
+A download overwrites an existing destination once response headers arrive. An interrupted download can leave a partial file. Use a temporary destination, check the status and any required checksum, and only then move it into place.
+
+Invalid control values throw immediately from `http()`, before a connection is opened or the destination is touched. Transport and file errors reject the future and throw when `.get()` is called. Timeouts report `HTTP request timed out`. Transport diagnostics omit the request URL and do not include header values or request bodies.
+
+The positional forms remain available with default controls: `http(url)`, `http(url, method)`, and `http(url, method, path)`. Use the struct form to configure headers, body, or request controls.
+
+## Runtime Compatibility
+
+This page describes **native MatchBox**, not the JVM HTTP client or browser fetch. MatchBox's request struct, future, and JSON result are distinct from JVM BoxLang's fluent HTTP client. The `timeout`, `connectionTimeout`, and `redirect` names follow BoxLang terminology; `noProxy` and `ipv4Only` are native MatchBox extensions. Do not assume these examples are drop-in JVM code.
+
+Successful HTTP future completion is not implemented for WASM/browser builds. These options do not add WASM HTTP support. See [Differences from BoxLang](differences-from-boxlang.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ Welcome to the MatchBox documentation. MatchBox is a native Rust implementation 
 
 | | |
 | :--- | :--- |
+| [HTTP Requests](http.md) | Native HTTP requests, deadlines, proxy bypass, IPv4-only probes, and downloads. |
 | [Differences from BoxLang (JVM)](differences-from-boxlang.md) | What is and isn't supported compared to the main BoxLang runtime. |
 | [Developer Guide](developer_guide.md) | Low-level architecture notes, tutorials, and CLI reference. |
 

--- a/tests/http_request_tests.rs
+++ b/tests/http_request_tests.rs
@@ -1,0 +1,496 @@
+#![cfg(all(feature = "bif-http", not(target_arch = "wasm32")))]
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::{Command, Output};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+fn serve(
+    listener: TcpListener,
+    maximum_requests: usize,
+    respond: impl Fn(&str, &mut TcpStream) + Send + 'static,
+) -> (SocketAddr, JoinHandle<Vec<String>>) {
+    let address = listener.local_addr().unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let worker = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut requests = Vec::new();
+        while requests.len() < maximum_requests && Instant::now() < deadline {
+            let (mut socket, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(error) => panic!("accept HTTP request: {error}"),
+            };
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut header = Vec::new();
+            while !header.ends_with(b"\r\n\r\n") {
+                let mut byte = [0];
+                socket.read_exact(&mut byte).unwrap();
+                header.push(byte[0]);
+                assert!(header.len() < 8192, "HTTP test header exceeded limit");
+            }
+            let mut request = String::from_utf8(header).unwrap();
+            let length = request
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            let mut body = vec![0; length];
+            socket.read_exact(&mut body).unwrap();
+            request.push_str(&String::from_utf8(body).unwrap());
+            respond(&request, &mut socket);
+            requests.push(request);
+        }
+        requests
+    });
+    (address, worker)
+}
+
+fn clear_proxies(command: &mut Command) {
+    for key in [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    ] {
+        command.env_remove(key);
+    }
+}
+
+fn run(source: &str, environment: &[(&str, String)]) -> Output {
+    let directory = tempfile::tempdir().unwrap();
+    let script = directory.path().join("http_test.bxs");
+    std::fs::write(&script, source).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_matchbox"));
+    command.arg(script);
+    clear_proxies(&mut command);
+    for (key, value) in environment {
+        command.env(key, value);
+    }
+    command.output().unwrap()
+}
+
+fn assert_success(output: Output) {
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn http_request_controls_work_in_a_standalone_native_binary() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let script = directory.path().join("probe.bxs");
+    let executable = directory
+        .path()
+        .join(format!("probe{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+        result = jsonDeserialize(http({{ url: "http://localhost:{port}/", timeout: 2,
+            connectionTimeout: 1, redirect: false, noProxy: true, ipv4Only: true }}).get());
+        if (result.status != 302 || result.body != "native") throw "native HTTP controls failed";
+    "#,
+            port = address.port()
+        ),
+    )
+    .unwrap();
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_matchbox"))
+            .args(["--target", "native", "--output"])
+            .arg(&executable)
+            .arg(script)
+            .output()
+            .unwrap(),
+    );
+    let (_, server) = serve(listener, 1, |_, socket| {
+        socket.write_all(b"HTTP/1.1 302 Found\r\nLocation: /not-followed\r\nContent-Length: 6\r\nConnection: close\r\n\r\nnative").unwrap();
+    });
+    let mut command = Command::new(executable);
+    clear_proxies(&mut command);
+    assert_success(
+        command
+            .env("HTTP_PROXY", "http://127.0.0.1:0")
+            .output()
+            .unwrap(),
+    );
+    assert_eq!(server.join().unwrap().len(), 1);
+}
+
+#[test]
+fn http_invalid_options_fail_before_network_or_file_side_effects() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let address = listener.local_addr().unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let download = directory.path().join("existing.txt");
+    std::fs::write(&download, "keep existing file").unwrap();
+    assert_success(run(
+        &format!(
+            r#"
+        for (option in ["timeout", "connectionTimeout", "redirect", "noProxy", "ipv4Only"]) {{
+            values = [null, "test-option-secret", {{}}, []];
+            if (option == "timeout" || option == "connectionTimeout") {{
+                values.append(false);
+                values.append(-1);
+                values.append(10 ^ 30);
+                values.append(10 ^ 19);
+                values.append(10 ^ 400);
+                values.append((-1) ^ 0.5);
+            }} else {{
+                values.append(1);
+                values.append("true");
+            }}
+            for (value in values) {{
+                spec = {{ url: "http://{address}/", path: {download} }};
+                spec[option] = value;
+                message = "";
+                try {{ http(spec); }} catch (any error) {{ message = error.message; }}
+                if (findNoCase(option, message) == 0 || findNoCase("must be", message) == 0)
+                    throw "invalid HTTP option must fail synchronously";
+                if (find("test-option-secret", message) > 0) throw "invalid options must not be echoed";
+            }}
+        }}
+    "#,
+            download = serde_json::to_string(&download).unwrap()
+        ),
+        &[],
+    ));
+    assert_eq!(
+        std::fs::read_to_string(download).unwrap(),
+        "keep existing file"
+    );
+    assert_eq!(
+        listener.accept().unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock
+    );
+}
+
+#[test]
+fn http_existing_calls_and_response_shapes_work_with_request_controls() {
+    let directory = tempfile::tempdir().unwrap();
+    let struct_download = directory.path().join("struct.txt");
+    let positional_download = directory.path().join("positional.txt");
+    let (address, server) = serve(
+        TcpListener::bind("127.0.0.1:0").unwrap(),
+        8,
+        |request, socket| {
+            let response = if request.starts_with("GET /redirect ") {
+                "HTTP/1.1 302 Found\r\nLocation: /missing\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            } else if request.starts_with("GET /missing ") {
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 7\r\nConnection: close\r\n\r\nmissing"
+            } else {
+                "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+            };
+            socket.write_all(response.as_bytes()).unwrap();
+        },
+    );
+    assert_success(run(
+        &format!(
+            r#"
+        result = jsonDeserialize(http("http://{address}/").get());
+        if (result.status != 200 || result.body != "ok" || result.file_content != "ok")
+            throw "positional URL and response fields must still work";
+        result = jsonDeserialize(http({{ url: "http://{address}/", method: "post",
+            headers: {{ Authorization: "Bearer loopback-test-secret", "Content-Type": "application/json" }},
+            body: '{{"model":"test"}}' }}).get());
+        if (result.status != 200) throw "POST must still work";
+        result = jsonDeserialize(http({{ url: "http://localhost:{port}/", path: {struct_download},
+            TiMeOuT: 0, ConnectionTimeout: 0, NoProxy: true, IPv4Only: true, Redirect: false }}).get());
+        if (result.status != 200 || result.file_path != {struct_download}) throw "struct download failed";
+        result = jsonDeserialize(http("http://{address}/", "GET", {positional_download}).get());
+        if (result.status != 200 || result.file_path != {positional_download}) throw "positional download failed";
+        result = jsonDeserialize(http({{ url: "http://{address}/redirect" }}).get());
+        if (result.status != 404 || result.body != "missing") throw "default redirects or error response failed";
+        result = jsonDeserialize(http({{ url: "http://{address}/redirect", redirect: true }}).get());
+        if (result.status != 404) throw "explicit redirect=true failed";
+    "#,
+            port = address.port(),
+            struct_download = serde_json::to_string(&struct_download).unwrap(),
+            positional_download = serde_json::to_string(&positional_download).unwrap()
+        ),
+        &[],
+    ));
+    assert_eq!(std::fs::read_to_string(struct_download).unwrap(), "ok");
+    assert_eq!(std::fs::read_to_string(positional_download).unwrap(), "ok");
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 8);
+    let post = requests
+        .iter()
+        .find(|request| request.starts_with("POST "))
+        .unwrap();
+    assert!(post
+        .to_ascii_lowercase()
+        .contains("authorization: bearer loopback-test-secret"));
+    assert!(post
+        .to_ascii_lowercase()
+        .contains("content-type: application/json"));
+    assert!(post.ends_with(r#"{"model":"test"}"#));
+}
+
+#[test]
+fn http_redirect_following_is_bounded() {
+    let (address, server) = serve(
+        TcpListener::bind("127.0.0.1:0").unwrap(),
+        11,
+        |_, socket| {
+            socket.write_all(b"HTTP/1.1 302 Found\r\nLocation: /loop\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").unwrap();
+        },
+    );
+    assert_success(run(
+        &format!(
+            r#"
+        message = "";
+        try {{ http({{ url: "http://{address}/loop", timeout: 2 }}).get(); }}
+        catch (any error) {{ message = error.message; }}
+        if (findNoCase("redirect", message) == 0) throw "redirect loops must fail with a redirect error";
+    "#
+        ),
+        &[],
+    ));
+    assert_eq!(server.join().unwrap().len(), 11);
+}
+
+#[test]
+fn http_errors_do_not_echo_credentials_or_request_data() {
+    assert_success(run(
+        r#"
+        for (authorization in ["Bearer header-secret", "Bearer header-secret" & chr(10)]) {
+            message = "";
+            try {
+                http({ url: "http://testuser:url-secret@127.0.0.1:0/?key=query-secret",
+                    method: "POST", headers: { Authorization: authorization }, body: "body-secret",
+                    timeout: 1, noProxy: true }).get();
+            } catch (any error) { message = error.message; }
+            if (findNoCase("HTTP request failed", message) == 0) throw "request should have failed";
+            for (secret in ["header-secret", "url-secret", "query-secret", "body-secret"]) {
+                if (find(secret, message) > 0) throw "HTTP diagnostics must not echo request data";
+            }
+        }
+    "#,
+        &[],
+    ));
+}
+
+#[test]
+fn http_ipv4_only_rejects_ipv6_including_redirects() {
+    let listener = match TcpListener::bind("[::1]:0") {
+        Ok(listener) => listener,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+            ) =>
+        {
+            eprintln!("IPv6 loopback unavailable; skipping IPv6-only assertions: {error}");
+            return;
+        }
+        Err(error) => panic!("bind IPv6 loopback: {error}"),
+    };
+    let (ipv6, target) = serve(listener, 3, |_, socket| {
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .unwrap();
+    });
+    let (ipv4, redirect) = serve(
+        TcpListener::bind("127.0.0.1:0").unwrap(),
+        1,
+        move |_, socket| {
+            write!(socket, "HTTP/1.1 302 Found\r\nLocation: http://{ipv6}/\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").unwrap();
+        },
+    );
+    assert_success(run(
+        &format!(
+            r#"
+        result = jsonDeserialize(http({{ url: "http://{ipv6}/", noProxy: true }}).get());
+        if (result.status != 200) throw "IPv6 loopback must work by default";
+        for (url in ["http://{ipv6}/", "http://{ipv4}/"]) {{
+            rejected = false;
+            try {{
+                http({{ url: url, ipv4Only: true, noProxy: true, timeout: 2 }}).get();
+            }} catch (any error) {{
+                rejected = findNoCase("HTTP request failed", error.message) > 0;
+            }}
+            if (!rejected) throw "ipv4Only must not connect to IPv6";
+        }}
+    "#
+        ),
+        &[],
+    ));
+    assert_eq!(redirect.join().unwrap().len(), 1);
+    assert_eq!(
+        target.join().unwrap().len(),
+        1,
+        "IPv4-only calls must not reach the IPv6 listener"
+    );
+}
+
+#[test]
+fn http_no_proxy_bypasses_environment_proxies_per_request() {
+    let (address, direct) = serve(TcpListener::bind("127.0.0.1:0").unwrap(), 1, |_, socket| {
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndirect")
+            .unwrap();
+    });
+    let (proxy_address, proxy) = serve(
+        TcpListener::bind("127.0.0.1:0").unwrap(),
+        2,
+        |_, socket| {
+            socket.write_all(b"HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 5\r\nConnection: close\r\n\r\nproxy").unwrap();
+        },
+    );
+    let environment: Vec<_> = [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ]
+    .map(|key| (key, format!("http://{proxy_address}")))
+    .into();
+    assert_success(run(
+        &format!(
+            r#"
+        result = jsonDeserialize(http({{ url: "http://{address}/", timeout: 2 }}).get());
+        if (result.status != 407 || result.body != "proxy") throw "default must honor proxy settings";
+        result = jsonDeserialize(http({{ url: "http://{address}/", noProxy: true, timeout: 2,
+            headers: {{ Authorization: "Bearer loopback-test-secret" }} }}).get());
+        if (result.status != 200 || result.body != "direct") throw "noProxy must connect directly";
+        result = jsonDeserialize(http({{ url: "http://{address}/", noProxy: false, timeout: 2 }}).get());
+        if (result.status != 407) throw "noProxy must not change proxies for later requests";
+    "#
+        ),
+        &environment,
+    ));
+    let direct_requests = direct.join().unwrap();
+    assert_eq!(direct_requests.len(), 1);
+    assert!(direct_requests[0]
+        .to_ascii_lowercase()
+        .contains("authorization: bearer loopback-test-secret"));
+    let proxy_requests = proxy.join().unwrap();
+    assert_eq!(proxy_requests.len(), 2);
+    assert!(proxy_requests
+        .iter()
+        .all(|request| !request.contains("loopback-test-secret")));
+}
+
+#[test]
+fn http_connection_timeout_bounds_a_stalled_tls_handshake() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (_socket, _) = listener.accept().unwrap();
+        thread::sleep(Duration::from_millis(500));
+    });
+    assert_success(run(
+        &format!(
+            r#"
+        timedOut = false;
+        try {{
+            http({{ url: "https://{address}/", connectionTimeout: 0.1, timeout: 2 }}).get();
+        }} catch (any error) {{
+            timedOut = findNoCase("timed out", error.message) > 0;
+        }}
+        if (!timedOut) throw "connectionTimeout must bound the TLS handshake";
+    "#
+        ),
+        &[],
+    ));
+    server.join().unwrap();
+}
+
+#[test]
+fn http_timeout_covers_headers_and_the_entire_response_body() {
+    let directory = tempfile::tempdir().unwrap();
+    let download = directory.path().join("download.txt");
+    for phase in ["headers", "body", "download"] {
+        let (address, server) = serve(
+            TcpListener::bind("127.0.0.1:0").unwrap(),
+            1,
+            move |_, socket| {
+                thread::sleep(Duration::from_millis(if phase == "headers" {
+                    400
+                } else {
+                    150
+                }));
+                let _ = socket.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n",
+                );
+                if phase != "headers" {
+                    thread::sleep(Duration::from_millis(150));
+                }
+                let _ = socket.write_all(b"ok");
+            },
+        );
+        let path = if phase == "download" {
+            format!(", path: {}", serde_json::to_string(&download).unwrap())
+        } else {
+            String::new()
+        };
+        assert_success(run(
+            &format!(
+                r#"
+            timedOut = false;
+            try {{
+                http({{ url: "http://{address}/", timeout: 0.25 {path} }}).get();
+            }} catch (any error) {{
+                timedOut = findNoCase("timed out", error.message) > 0;
+            }}
+            if (!timedOut) throw "HTTP {phase} must observe the total request timeout";
+        "#
+            ),
+            &[],
+        ));
+        assert_eq!(server.join().unwrap().len(), 1);
+    }
+}
+
+#[test]
+fn http_redirect_can_be_disabled() {
+    let (address, server) = serve(
+        TcpListener::bind("127.0.0.1:0").unwrap(),
+        2,
+        |request, socket| {
+            let response = if request.starts_with("GET /redirect ") {
+                "HTTP/1.1 302 Found\r\nLocation: /target\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            } else {
+                "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+            };
+            socket.write_all(response.as_bytes()).unwrap();
+        },
+    );
+    let output = run(
+        &format!(
+            r#"
+        result = jsonDeserialize(http({{ url: "http://{address}/redirect", redirect: false }}).get());
+        if (result.status != 302) throw "redirect=false must return the original response";
+    "#
+        ),
+        &[],
+    );
+    assert_success(output);
+    assert_eq!(
+        server.join().unwrap().len(),
+        1,
+        "redirect target must not be requested"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #43.

- Add `timeout`, `connectionTimeout`, `redirect`, `noProxy`, and `ipv4Only` to the native HTTP request specification using existing reqwest capabilities.
- Validate controls before network/file side effects, enforce a total response-body deadline, and omit credentials/request URLs from transport diagnostics.
- Exercise the public BIF and standalone native output with 10 loopback tests; document options and the native/JVM API distinction.

## Verification

- `cargo test --workspace --no-fail-fast`: 992 passed, 0 failed, 23 ignored.
- `cargo clippy --workspace --all-targets`: passed with existing warnings, none in changed HTTP/test code.
- `cargo build --release --features 'bif-http,bif-zip'`: passed.
- HTTP-disabled VM and `wasm32-unknown-unknown` VM (`bif-http,js`) checks: passed; WASM HTTP execution remains unsupported.
- Targeted rustfmt, whitespace, and documentation-link checks: passed.

No new dependencies or full JVM fluent-client rewrite. Downstream agentctl will pin this published commit when adopting the controls.
